### PR TITLE
Make animations parameter optional for UITableView extension

### DIFF
--- a/Diffuse/Extensions/UITableViewExtensions.swift
+++ b/Diffuse/Extensions/UITableViewExtensions.swift
@@ -12,15 +12,15 @@ extension UITableView {
     }
 
     public func reload(with changes: CollectionChanges,
-                       animations: [Operation: RowAnimation]?,
+                       animations: [Operation: RowAnimation] = [:],
                        section: Int = 0,
                        updateDataSource: () -> Void) {
         guard changes.count != 0 else { return }
         let indexPaths = IndexPathResult(changes: changes, section: section)
 
-        let insertAnimation = animations?[.insert] ?? .automatic
-        let reloadAnimation = animations?[.reload] ?? .automatic
-        let deleteAnimation = animations?[.delete] ?? .automatic
+        let insertAnimation = animations[.insert] ?? .automatic
+        let reloadAnimation = animations[.reload] ?? .automatic
+        let deleteAnimation = animations[.delete] ?? .automatic
 
         if #available(iOS 11, *) {
             performBatchUpdates({


### PR DESCRIPTION
# Why
The parameter for `animations` in our `UITableView` extension should be optional.