### PR TITLE
Add podspec for CocoaPods

### DIFF
--- a/Diffuse.podspec
+++ b/Diffuse.podspec
@@ -13,11 +13,7 @@ Pod::Spec.new do |s|
   - indices that has been updated
                    DESC
   s.license          = 'MIT'
-
-  s.ios.deployment_target = '10.0'
-  s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '10.0'
-
+  s.platform         = :ios, '10.0'
   s.requires_arc     = true
   s.swift_version    = '4.2'
   s.source_files     = 'Diffuse/**/*'

--- a/Diffuse.podspec
+++ b/Diffuse.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name             = 'Diffuse'
+  s.summary          = 'A library that aims to simplify the diffing of two collections'
+  s.version          = '0.1.0'
+  s.author           = 'FINN.no'
+  s.social_media_url = 'https://twitter.com/FINN_tech'
+  s.source           = { :git => "https://github.com/finn-no/Diffuse", :tag => s.version }
+  s.description      = <<-DESC
+  Diffuse is library that aims to simplify the diffing of two collections. After diffing you get to know:
+  - indices where insertion has happened
+  - indices that has been removed
+  - indices that has moved
+  - indices that has been updated
+                   DESC
+  s.license          = 'MIT'
+
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.10'
+  s.tvos.deployment_target = '10.0'
+
+  s.requires_arc     = true
+  s.swift_version    = '4.2'
+  s.source_files     = 'Diffuse/**/*'
+  s.frameworks       = 'Foundation', 'UIKit'
+end

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Currently we have two different methods, each with their own algorithm. They bot
 github "finn-no/Diffuse"
 ```
 
+`Diffuse` is also available through [CocoaPods](http://cocoapods.org). To install it, simply add the following line to your Podfile:
+
+```ruby
+pod 'Diffuse'
+```
+
 ## Usage
 As mentioned, we have two different methods/algorithms:
 - `diff<T: Hashable>(old: [T], new: [T]) -> CollectionChanges`
@@ -78,7 +84,7 @@ tableView.reload(with: changes, section: 1, updateDataSource: { dataSource.model
 ### `Diffuse.diff(old: [T], new: [T])`
 This one is *faaaaast*! 🏎🔥 You could say its compexity is `O(damn that's swift)`😮 Jokes aside, it's actually `O(n)`.
 
-This algorithm is usable for both Swift "primitives" and more complex structures, and uses `hashValue` for comparison. This means element in your collections must implement the `Hashable` protocol. 
+This algorithm is usable for both Swift "primitives" and more complex structures, and uses `hashValue` for comparison. This means element in your collections must implement the `Hashable` protocol.
 
 #### Caveats
 Since we're using the elements `hashValue` for comparison, this algorithm won't be directly able to figure out updates to an element. An updated element will have a different `hashValue` than the old element. This makes the algorithm think the old element is removed and the updated element is inserted, given that the index is the same.
@@ -158,7 +164,7 @@ print(changes.updated)   // [1]                  <- Element B/D
 
 ### `Diffuse.diff(old: [T], new: [T], comparator: (T, T) -> Bool)`
 
-The algorithm this method uses isn't as fast as `diff(old:new)`, but it gives you more control when comparing complex elements. It takes a closure as one of its parameters, so you can control how you would like to compare the elements. This is useful if you explicitly need to know which elements has been updated. This works best if your elements has some form of unique identifier, like `id`. 
+The algorithm this method uses isn't as fast as `diff(old:new)`, but it gives you more control when comparing complex elements. It takes a closure as one of its parameters, so you can control how you would like to compare the elements. This is useful if you explicitly need to know which elements has been updated. This works best if your elements has some form of unique identifier, like `id`.
 
 Note that all elements must implement `Equatable`.
 


### PR DESCRIPTION
# Why?

In case people want to install `Diffuse` through `CocoaPods`.

# What?

Add `Diffuse.podspec` file.
