### PR TITLE
Added homepage to podspec, updated github_source

### DIFF
--- a/Diffuse.podspec
+++ b/Diffuse.podspec
@@ -3,8 +3,9 @@ Pod::Spec.new do |s|
   s.summary          = 'A library that aims to simplify the diffing of two collections'
   s.version          = '0.1.0'
   s.author           = 'FINN.no'
+  s.homepage         = 'https://github.com/finn-no/Diffuse'
   s.social_media_url = 'https://twitter.com/FINN_tech'
-  s.source           = { :git => "https://github.com/finn-no/Diffuse", :tag => s.version }
+  s.source           = { :git => 'https://github.com/finn-no/Diffuse.git', :tag => s.version }
   s.description      = <<-DESC
   Diffuse is library that aims to simplify the diffing of two collections. After diffing you get to know:
   - indices where insertion has happened


### PR DESCRIPTION
# Why?
The podspec was missing `homepage`, and the GitHub URL was not ending in `.git`.

# What?
- Added missing to podspec.